### PR TITLE
Explicitly set LoadLibraryA

### DIFF
--- a/examples/import_shared_library.c
+++ b/examples/import_shared_library.c
@@ -26,7 +26,7 @@ static void cb_logMessage(fmi3InstanceEnvironment instanceEnvironment, fmi3Strin
 int main(int argc, char* argv[]) {
 
 #if defined(_WIN32)
-    HMODULE libraryHandle = LoadLibrary("VanDerPol\\binaries\\x86_64-windows\\VanDerPol.dll");
+    HMODULE libraryHandle = LoadLibraryA("VanDerPol\\binaries\\x86_64-windows\\VanDerPol.dll");
 #elif defined(__APPLE__)
     void *libraryHandle = dlopen("VanDerPol/binaries/x86_64-darwin/VanDerPol.dylib", RTLD_LAZY);
 #else


### PR DESCRIPTION
Avoid dependency on ANSI or Unicode build by explicitly setting LoadLibraryA for narrow string. Otherwise compilation will fail if `_UNICODE` is defined.