### PR TITLE
Fix wording in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 
 The Reference FMUs are a fork of the Test FMUs (https://github.com/CATIA-Systems/Test-FMUs)
-by Dassault Systemes, which is are a fork of the FMU SDK (https://github.com/qtronic/fmusdk)
+by Dassault Systemes, which are a fork of the FMU SDK (https://github.com/qtronic/fmusdk)
 by QTronic, both released under the 2-Clause BSD License.
 
 The FMI header files are copyright (c) 2008-2011 MODELISAR consortium, 2012-2020


### PR DESCRIPTION
Actually, the  wording "are a fork of" is confusing as it is not a forked GitHub repository. Maybe it should be written as "are derived from".