### PR TITLE
Remove start attribute in Clocks/FMI3.xml to be valid according the XML schema

### DIFF
--- a/Clocks/FMI3.xml
+++ b/Clocks/FMI3.xml
@@ -8,9 +8,9 @@
  <DefaultExperiment stopTime="10" stepSize="1"/>
  <ModelVariables>
   <Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
-  <Clock name="inClock1" valueReference="1001" start="0" causality="input" interval="constant" intervalDecimal="1.0" priority="0"/>
-  <Clock name="inClock2" valueReference="1002" start="0" causality="input" interval="triggered" priority="1"/>
-  <Clock name="inClock3" valueReference="1003" start="0" causality="input" interval="countdown" priority="2" clocks="1001"/>
+  <Clock name="inClock1" valueReference="1001" causality="input" interval="constant" intervalDecimal="1.0" priority="0"/>
+  <Clock name="inClock2" valueReference="1002" causality="input" interval="triggered" priority="1"/>
+  <Clock name="inClock3" valueReference="1003" causality="input" interval="countdown" priority="2" clocks="1001"/>
   <Clock name="outClock" valueReference="1005" causality="output" interval="triggered" priority="2" clocks="1001 1002 1003"/>
   <Int32 name="inClock1Ticks" valueReference="2001" causality="output" clocks="1001"/>
   <Int32 name="inClock2Ticks" valueReference="2002" causality="output" clocks="1002"/>

--- a/Resource/model.c
+++ b/Resource/model.c
@@ -33,9 +33,13 @@ void calculateValues(ModelInstance *comp) {
 #ifdef _WIN32
     DWORD pathLen = MAX_PATH_LENGTH;
 
+#if FMI_VERSION < 3
     if (PathCreateFromUrl(comp->resourceLocation, path, &pathLen, 0) != S_OK) {
         return;
     }
+#else
+    strncpy(path, comp->resourceLocation, MAX_PATH_LENGTH);
+#endif
 
 #if FMI_VERSION < 2
     if (!PathAppend(path, "resources")) return;

--- a/Resource/model.c
+++ b/Resource/model.c
@@ -49,19 +49,23 @@ void calculateValues(ModelInstance *comp) {
 
 #else
 
+#if FMI_VERSION < 3
     if (strncmp(comp->resourceLocation, scheme1, strlen(scheme1)) == 0) {
-        strcpy(path, &comp->resourceLocation[strlen(scheme1)] - 1);
+        strncpy(path, &comp->resourceLocation[strlen(scheme1)] - 1, MAX_PATH_LENGTH);
     } else if (strncmp(comp->resourceLocation, scheme2, strlen(scheme2)) == 0) {
-        strcpy(path, &comp->resourceLocation[strlen(scheme2) - 1]);
+        strncpy(path, &comp->resourceLocation[strlen(scheme2) - 1], MAX_PATH_LENGTH);
     } else {
         logError(comp, "The resourceLocation must start with \"file:/\" or \"file:///\"");
         return;
     }
+#else
+    strncpy(path, &comp->resourceLocation, MAX_PATH_LENGTH);
+#endif
 
 #if FMI_VERSION < 2
-    strcat(path, "/resources/y.txt");
+    strncat(path, "/resources/y.txt", MAX_PATH_LENGTH);
 #else
-    strcat(path, "/y.txt");
+    strncat(path, "/y.txt", MAX_PATH_LENGTH);
 #endif
 
 #endif

--- a/Resource/model.c
+++ b/Resource/model.c
@@ -59,7 +59,7 @@ void calculateValues(ModelInstance *comp) {
         return;
     }
 #else
-    strncpy(path, &comp->resourceLocation, MAX_PATH_LENGTH);
+    strncpy(path, comp->resourceLocation, MAX_PATH_LENGTH);
 #endif
 
 #if FMI_VERSION < 2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  fmpy: https://github.com/CATIA-Systems/FMPy/archive/dbd083eba7b3ba84b023f9dcabb639452da668a8.zip
+  fmpy: https://github.com/CATIA-Systems/FMPy/archive/548a9a8d4c1589eb1ffa133c86472dfc33163002.zip
   conda.packages: python=3.7 dask lark-parser lxml numpy pathlib pip pytest requests scipy
 
 jobs:


### PR DESCRIPTION
The current FMI 2.0 XML schema files do not allow an start attribute for Clock's. Hence, removed this attribute such that the files validate again.