### PR TITLE
Fix vr in dim of y of LinearTransform FMU

### DIFF
--- a/LinearTransform/FMI3.xml
+++ b/LinearTransform/FMI3.xml
@@ -34,7 +34,7 @@
       <Dimension valueReference="2"/>
     </Float64>
     <Float64 name="y" valueReference="5" causality="output">
-      <Dimension valueReference="2"/>
+      <Dimension valueReference="1"/>
     </Float64>
   </ModelVariables>
 


### PR DESCRIPTION
The valueReference used in the dimension of y of the LinearTransform FMU seams wrong (it shouldn't be the same as the one used for u).