### PR TITLE
Detect unsupported VS at configure time (and not at compile time)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,12 @@ if (MSVC)
   string(REPLACE "/MD"  "/MT"  CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
   string(REPLACE "/MDd" "/MTd" CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}")
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+
+  # Minimum supported MSVC version is 1800 = Visual Studio 12.0/2013
+  # See also https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html
+  if (MSVC_VERSION VERSION_LESS 1800)
+    message (SEND_ERROR "MSVC_VERSION ${MSVC_VERSION} is not a supported Visual Studio compiler version. Please use Visual Studio 2013 or any later version.")
+  endif ()
 endif ()
 
 add_compile_definitions(FMI_VERSION=${FMI_VERSION})


### PR DESCRIPTION
I successfully run CMake configuration on recent master for VS2010. If I open the generated VS solution in VS2010 I get a compiler error that stdbool.h could not be found. Such kind of compiler version requirements should not occur such late during compile time, but at configuration time.