### PR TITLE
Add reference CSV to FMU documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,12 @@ add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E 
   "${FMU_BUILD_DIR}/documentation/${MODEL_NAME}_ref.svg"
 )
 
+# reference csv
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
+  "${CMAKE_CURRENT_SOURCE_DIR}/${MODEL_NAME}/${MODEL_NAME}_ref.csv"
+  "${FMU_BUILD_DIR}/documentation/${MODEL_NAME}_ref.csv"
+)
+
 # license
 add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
   "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt"


### PR DESCRIPTION
Since the CSV is referenced from the index.html it should be added as well.