### PR TITLE
Fix build workflow for set_tool_version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ ENDFUNCTION()
 
 project (Reference-FMUs)
 
+find_package (Python3)
+find_package (Git)
+
 set(FMI_VERSION 2 CACHE STRING "FMI Version")
 set_property(CACHE FMI_VERSION PROPERTY STRINGS 1 2 3)
 
@@ -164,9 +167,11 @@ add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E 
   "${FMU_BUILD_DIR}/modelDescription.xml"
 )
 
-add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/set_tool_version.py"
-  "${FMU_BUILD_DIR}/modelDescription.xml"
-)
+if (${Python3_Interpreter_FOUND} AND ${Git_FOUND})
+  add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/set_tool_version.py"
+    "${FMU_BUILD_DIR}/modelDescription.xml" "${GIT_EXECUTABLE}"
+  )
+endif()
 
 # model specific header and source
 foreach (SOURCE_FILE config.h model.c)

--- a/set_tool_version.py
+++ b/set_tool_version.py
@@ -1,22 +1,22 @@
+import os.path
 import subprocess
 import sys
-import os
 
 
-def set_tool_version(filename):
+def set_tool_version(filename, git_executable='git'):
     """ Set the Git tag or hash in the generationTool attribute if the repo is clean """
 
     cwd = os.path.dirname(__file__)
-
-    changed_files = subprocess.check_output(['git', 'status', '--porcelain', '--untracked=no'], cwd=cwd).decode('ascii').strip()
+    
+    changed_files = subprocess.check_output([git_executable, 'status', '--porcelain', '--untracked=no'], cwd=cwd).decode('ascii').strip()
 
     if changed_files:
         return
 
-    version = subprocess.check_output(['git', 'tag', '--contains'], cwd=cwd).decode('ascii').strip()
+    version = subprocess.check_output([git_executable, 'tag', '--contains'], cwd=cwd).decode('ascii').strip()
 
     if not version:
-        version = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], cwd=cwd).decode('ascii').strip()
+        version = subprocess.check_output([git_executable, 'rev-parse', '--short', 'HEAD'], cwd=cwd).decode('ascii').strip()
 
     if not version:
         return
@@ -33,6 +33,11 @@ def set_tool_version(filename):
 if __name__ == '__main__':
 
     try:
-        set_tool_version(sys.argv[1])
+        if len(sys.argv) > 2:
+            set_tool_version(sys.argv[1], sys.argv[2])
+        elif len(sys.argv) > 1:
+            set_tool_version(sys.argv[1])
+        else:
+            raise RuntimeError('Not enough arguments')
     except Exception as e:
         print(e)


### PR DESCRIPTION
Recent f639f7ab674b83f74a42a8014010e14c9dd7562d broke the post-build setup in my environment where Python and Git are not on path. This PR correctly considers the case where Python and Git are not on path.