### PR TITLE
Do not check for untracked files

### DIFF
--- a/set_tool_version.py
+++ b/set_tool_version.py
@@ -8,7 +8,7 @@ def set_tool_version(filename):
 
     cwd = os.path.dirname(__file__)
 
-    changed_files = subprocess.check_output(['git', 'status', '--porcelain'], cwd=cwd).decode('ascii').strip()
+    changed_files = subprocess.check_output(['git', 'status', '--porcelain', '--untracked=no'], cwd=cwd).decode('ascii').strip()
 
     if changed_files:
         return


### PR DESCRIPTION
Enable custom build directories on root level (beside the default build directory `build`).