### PR TITLE
Improve C macro style

### DIFF
--- a/BouncingBall/model.c
+++ b/BouncingBall/model.c
@@ -138,24 +138,24 @@ void eventUpdate(ModelInstance *comp) {
 }
 
 void getContinuousStates(ModelInstance *comp, double x[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     x[0] = M(h);
     x[1] = M(v);
 }
 
 void setContinuousStates(ModelInstance *comp, const double x[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     M(h) = x[0];
     M(v) = x[1];
 }
 
 void getDerivatives(ModelInstance *comp, double dx[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     dx[0] = M(v);
     dx[1] = M(g);
 }
 
 void getEventIndicators(ModelInstance *comp, double z[], size_t nz) {
-    UNUSED(nz)
+    UNUSED(nz);
     z[0] = (M(h) == 0 && M(v) == 0) ? 1 : M(h);
 }

--- a/Dahlquist/model.c
+++ b/Dahlquist/model.c
@@ -56,17 +56,17 @@ Status setFloat64(ModelInstance* comp, ValueReference vr, const double *value, s
 }
 
 void getContinuousStates(ModelInstance *comp, double x[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     x[0] = M(x);
 }
 
 void setContinuousStates(ModelInstance *comp, const double x[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     M(x) = x[0];
 }
 
 void getDerivatives(ModelInstance *comp, double dx[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     calculateValues(comp);
     dx[0] = M(der_x);
 }

--- a/VanDerPol/model.c
+++ b/VanDerPol/model.c
@@ -68,20 +68,20 @@ Status setFloat64(ModelInstance* comp, ValueReference vr, const double *value, s
 }
 
 void getContinuousStates(ModelInstance *comp, double x[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     x[0] = M(x0);
     x[1] = M(x1);
 }
 
 void setContinuousStates(ModelInstance *comp, const double x[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     M(x0) = x[0];
     M(x1) = x[1];
     calculateValues(comp);
 }
 
 void getDerivatives(ModelInstance *comp, double dx[], size_t nx) {
-    UNUSED(nx)
+    UNUSED(nx);
     calculateValues(comp);
     dx[0] = M(der_x0);
     dx[1] = M(der_x1);

--- a/include/model.h
+++ b/include/model.h
@@ -5,7 +5,7 @@
 #error FMI_VERSION must be one of 1, 2 or 3
 #endif
 
-#define UNUSED(x) (void)(x);
+#define UNUSED(x) (void)(x)
 
 #include <stddef.h>  // for size_t
 #include <stdbool.h> // for bool

--- a/src/FMI1.c
+++ b/src/FMI1.c
@@ -54,29 +54,36 @@ static void *loadSymbol(FMIInstance *instance, const char *prefix, const char *n
 }
 
 #define LOAD_SYMBOL(f) \
+do { \
     instance->fmi1Functions->fmi1 ## f = (fmi1 ## f ## TYPE*)loadSymbol(instance, modelIdentifier, "_fmi" #f); \
     if (!instance->fmi1Functions->fmi1 ## f) { \
         status = fmi1Error; \
         goto fail; \
-    }
+    } \
+} while (0)
 
 #define CALL(f) \
+do { \
     currentInstance = instance; \
     fmi1Status status = instance->fmi1Functions->fmi1 ## f (instance->component); \
     if (instance->logFunctionCall) { \
         instance->logFunctionCall(instance, status, "fmi" #f "()"); \
     } \
-    return status;
+    return status; \
+} while (0)
 
 #define CALL_ARGS(f, m, ...) \
+do { \
     currentInstance = instance; \
     fmi1Status status = instance->fmi1Functions->fmi1 ## f (instance->component, __VA_ARGS__); \
     if (instance->logFunctionCall) { \
         instance->logFunctionCall(instance, status, "fmi" #f "(" m ")", __VA_ARGS__); \
     } \
-    return status;
+    return status; \
+} while (0)
 
 #define CALL_ARRAY(s, t) \
+do { \
     currentInstance = instance; \
     fmi1Status status = instance->fmi1Functions->fmi1 ## s ## t(instance->component, vr, nvr, value); \
     if (instance->logFunctionCall) { \
@@ -84,7 +91,8 @@ static void *loadSymbol(FMIInstance *instance, const char *prefix, const char *n
         FMIValuesToString(instance, nvr, value, FMI ## t ## Type); \
         instance->logFunctionCall(instance, status, "fmi" #s #t "(vr=%s, nvr=%zu, value=%s)", instance->buf1, nvr, instance->buf2); \
     } \
-    return status;
+    return status; \
+} while (0)
 
 /***************************************************
  Common Functions for FMI 1.0

--- a/src/FMI2.c
+++ b/src/FMI2.c
@@ -44,45 +44,57 @@ static void cb_logMessage2(fmi2ComponentEnvironment componentEnvironment, fmi2St
 
 #if defined(FMI2_FUNCTION_PREFIX)
 #define LOAD_SYMBOL(f) \
-    instance->fmi2Functions->fmi2 ## f = fmi2 ## f;
+do { \
+    instance->fmi2Functions->fmi2 ## f = fmi2 ## f; \
+} while (0)
 #elif defined(_WIN32)
 #define LOAD_SYMBOL(f) \
+do { \
     instance->fmi2Functions->fmi2 ## f = (fmi2 ## f ## TYPE*)GetProcAddress(instance->libraryHandle, "fmi2" #f); \
     if (!instance->fmi2Functions->fmi2 ## f) { \
         instance->logMessage(instance, FMIFatal, "fatal", "Symbol fmi2" #f " is missing in shared library."); \
         return fmi2Fatal; \
-    }
+    }\
+} while (0)
 #else
 #define LOAD_SYMBOL(f) \
+do { \
     instance->fmi2Functions->fmi2 ## f = (fmi2 ## f ## TYPE*)dlsym(instance->libraryHandle, "fmi2" #f); \
     if (!instance->fmi2Functions->fmi2 ## f) { \
         instance->logMessage(instance, FMIFatal, "fatal", "Symbol fmi2" #f " is missing in shared library."); \
         return fmi2Fatal; \
-    }
+    } \
+} while (0)
 #endif
 
 #define CALL(f) \
+do { \
     fmi2Status status = instance->fmi2Functions->fmi2 ## f (instance->component); \
     if (instance->logFunctionCall) { \
         instance->logFunctionCall(instance, status, "fmi2" #f "()"); \
     } \
-    return status;
+    return status; \
+} while (0)
 
 #define CALL_ARGS(f, m, ...) \
+do { \
     fmi2Status status = instance->fmi2Functions-> fmi2 ## f (instance->component, __VA_ARGS__); \
     if (instance->logFunctionCall) { \
         instance->logFunctionCall(instance, status, "fmi2" #f "(" m ")", __VA_ARGS__); \
     } \
-    return status;
+    return status; \
+} while (0)
 
 #define CALL_ARRAY(s, t) \
+do { \
     fmi2Status status = instance->fmi2Functions->fmi2 ## s ## t(instance->component, vr, nvr, value); \
     if (instance->logFunctionCall) { \
         FMIValueReferencesToString(instance, vr, nvr); \
         FMIValuesToString(instance, nvr, value, FMI ## t ## Type); \
         instance->logFunctionCall(instance, status, "fmi2" #s #t "(vr=%s, nvr=%zu, value=%s)", instance->buf1, nvr, instance->buf2); \
     } \
-    return status;
+    return status; \
+} while (0)
 
 /***************************************************
 Common Functions
@@ -141,33 +153,33 @@ fmi2Status FMI2Instantiate(FMIInstance *instance, const char *fmuResourceLocatio
     ****************************************************/
 
     /* required functions */
-    LOAD_SYMBOL(GetTypesPlatform)
-    LOAD_SYMBOL(GetVersion)
-    LOAD_SYMBOL(SetDebugLogging)
-    LOAD_SYMBOL(Instantiate)
-    LOAD_SYMBOL(FreeInstance)
-    LOAD_SYMBOL(SetupExperiment)
-    LOAD_SYMBOL(EnterInitializationMode)
-    LOAD_SYMBOL(ExitInitializationMode)
-    LOAD_SYMBOL(Terminate)
-    LOAD_SYMBOL(Reset)
-    LOAD_SYMBOL(GetReal)
-    LOAD_SYMBOL(GetInteger)
-    LOAD_SYMBOL(GetBoolean)
-    LOAD_SYMBOL(GetString)
-    LOAD_SYMBOL(SetReal)
-    LOAD_SYMBOL(SetInteger)
-    LOAD_SYMBOL(SetBoolean)
-    LOAD_SYMBOL(SetString)
+    LOAD_SYMBOL(GetTypesPlatform);
+    LOAD_SYMBOL(GetVersion);
+    LOAD_SYMBOL(SetDebugLogging);
+    LOAD_SYMBOL(Instantiate);
+    LOAD_SYMBOL(FreeInstance);
+    LOAD_SYMBOL(SetupExperiment);
+    LOAD_SYMBOL(EnterInitializationMode);
+    LOAD_SYMBOL(ExitInitializationMode);
+    LOAD_SYMBOL(Terminate);
+    LOAD_SYMBOL(Reset);
+    LOAD_SYMBOL(GetReal);
+    LOAD_SYMBOL(GetInteger);
+    LOAD_SYMBOL(GetBoolean);
+    LOAD_SYMBOL(GetString);
+    LOAD_SYMBOL(SetReal);
+    LOAD_SYMBOL(SetInteger);
+    LOAD_SYMBOL(SetBoolean);
+    LOAD_SYMBOL(SetString);
 
     /* optional functions */
-    LOAD_SYMBOL(GetFMUstate)
-    LOAD_SYMBOL(SetFMUstate)
-    LOAD_SYMBOL(FreeFMUstate)
-    LOAD_SYMBOL(SerializedFMUstateSize)
-    LOAD_SYMBOL(SerializeFMUstate)
-    LOAD_SYMBOL(DeSerializeFMUstate)
-    LOAD_SYMBOL(GetDirectionalDerivative)
+    LOAD_SYMBOL(GetFMUstate);
+    LOAD_SYMBOL(SetFMUstate);
+    LOAD_SYMBOL(FreeFMUstate);
+    LOAD_SYMBOL(SerializedFMUstateSize);
+    LOAD_SYMBOL(SerializeFMUstate);
+    LOAD_SYMBOL(DeSerializeFMUstate);
+    LOAD_SYMBOL(GetDirectionalDerivative);
 
     if (fmuType == fmi2ModelExchange) {
 #ifndef CO_SIMULATION
@@ -175,16 +187,16 @@ fmi2Status FMI2Instantiate(FMIInstance *instance, const char *fmuResourceLocatio
         Model Exchange
         ****************************************************/
 
-        LOAD_SYMBOL(EnterEventMode)
-        LOAD_SYMBOL(NewDiscreteStates)
-        LOAD_SYMBOL(EnterContinuousTimeMode)
-        LOAD_SYMBOL(CompletedIntegratorStep)
-        LOAD_SYMBOL(SetTime)
-        LOAD_SYMBOL(SetContinuousStates)
-        LOAD_SYMBOL(GetDerivatives)
-        LOAD_SYMBOL(GetEventIndicators)
-        LOAD_SYMBOL(GetContinuousStates)
-        LOAD_SYMBOL(GetNominalsOfContinuousStates)
+        LOAD_SYMBOL(EnterEventMode);
+        LOAD_SYMBOL(NewDiscreteStates);
+        LOAD_SYMBOL(EnterContinuousTimeMode);
+        LOAD_SYMBOL(CompletedIntegratorStep);
+        LOAD_SYMBOL(SetTime);
+        LOAD_SYMBOL(SetContinuousStates);
+        LOAD_SYMBOL(GetDerivatives);
+        LOAD_SYMBOL(GetEventIndicators);
+        LOAD_SYMBOL(GetContinuousStates);
+        LOAD_SYMBOL(GetNominalsOfContinuousStates);
 #endif
     } else {
 #ifndef MODEL_EXCHANGE
@@ -192,15 +204,15 @@ fmi2Status FMI2Instantiate(FMIInstance *instance, const char *fmuResourceLocatio
         Co-Simulation
         ****************************************************/
 
-        LOAD_SYMBOL(SetRealInputDerivatives)
-        LOAD_SYMBOL(GetRealOutputDerivatives)
-        LOAD_SYMBOL(DoStep)
-        LOAD_SYMBOL(CancelStep)
-        LOAD_SYMBOL(GetStatus)
-        LOAD_SYMBOL(GetRealStatus)
-        LOAD_SYMBOL(GetIntegerStatus)
-        LOAD_SYMBOL(GetBooleanStatus)
-        LOAD_SYMBOL(GetStringStatus)
+        LOAD_SYMBOL(SetRealInputDerivatives);
+        LOAD_SYMBOL(GetRealOutputDerivatives);
+        LOAD_SYMBOL(DoStep);
+        LOAD_SYMBOL(CancelStep);
+        LOAD_SYMBOL(GetStatus);
+        LOAD_SYMBOL(GetRealStatus);
+        LOAD_SYMBOL(GetIntegerStatus);
+        LOAD_SYMBOL(GetBooleanStatus);
+        LOAD_SYMBOL(GetStringStatus);
 #endif
     }
 
@@ -255,68 +267,68 @@ fmi2Status FMI2SetupExperiment(FMIInstance *instance,
 
 fmi2Status FMI2EnterInitializationMode(FMIInstance *instance) {
     instance->state = FMI2InitializationModeState;
-    CALL(EnterInitializationMode)
+    CALL(EnterInitializationMode);
 }
 
 fmi2Status FMI2ExitInitializationMode(FMIInstance *instance) {
     instance->state = instance->interfaceType == FMIModelExchange ? FMI2EventModeState : FMI2StepCompleteState;
-    CALL(ExitInitializationMode)
+    CALL(ExitInitializationMode);
 }
 
 fmi2Status FMI2Terminate(FMIInstance *instance) {
     instance->state = FMI2TerminatedState;
-    CALL(Terminate)
+    CALL(Terminate);
 }
 
 fmi2Status FMI2Reset(FMIInstance *instance) {
     instance->state = FMI2InstantiatedState;
-    CALL(Reset)
+    CALL(Reset);
 }
 
 /* Getting and setting variable values */
 fmi2Status FMI2GetReal(FMIInstance *instance, const fmi2ValueReference vr[], size_t nvr, fmi2Real value[]) {
-    CALL_ARRAY(Get, Real)
+    CALL_ARRAY(Get, Real);
 }
 
 fmi2Status FMI2GetInteger(FMIInstance *instance, const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[]) {
-    CALL_ARRAY(Get, Integer)
+    CALL_ARRAY(Get, Integer);
 }
 
 fmi2Status FMI2GetBoolean(FMIInstance *instance, const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[]) {
-    CALL_ARRAY(Get, Boolean)
+    CALL_ARRAY(Get, Boolean);
 }
 
 fmi2Status FMI2GetString(FMIInstance *instance, const fmi2ValueReference vr[], size_t nvr, fmi2String value[]) {
-    CALL_ARRAY(Get, String)
+    CALL_ARRAY(Get, String);
 }
 
 fmi2Status FMI2SetReal(FMIInstance *instance, const fmi2ValueReference vr[], size_t nvr, const fmi2Real value[]) {
-    CALL_ARRAY(Set, Real)
+    CALL_ARRAY(Set, Real);
 }
 
 fmi2Status FMI2SetInteger(FMIInstance *instance, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[]) {
-    CALL_ARRAY(Set, Integer)
+    CALL_ARRAY(Set, Integer);
 }
 
 fmi2Status FMI2SetBoolean(FMIInstance *instance, const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[]) {
-    CALL_ARRAY(Set, Boolean)
+    CALL_ARRAY(Set, Boolean);
 }
 
 fmi2Status FMI2SetString(FMIInstance *instance, const fmi2ValueReference vr[], size_t nvr, const fmi2String value[]) {
-    CALL_ARRAY(Set, String)
+    CALL_ARRAY(Set, String);
 }
 
 /* Getting and setting the internal FMU state */
 fmi2Status FMI2GetFMUstate(FMIInstance *instance, fmi2FMUstate* FMUstate) {
-    CALL_ARGS(GetFMUstate, "FMUstate=0x%p", FMUstate)
+    CALL_ARGS(GetFMUstate, "FMUstate=0x%p", FMUstate);
 }
 
 fmi2Status FMI2SetFMUstate(FMIInstance *instance, fmi2FMUstate  FMUstate) {
-    CALL_ARGS(SetFMUstate, "FMUstate=0x%p", FMUstate)
+    CALL_ARGS(SetFMUstate, "FMUstate=0x%p", FMUstate);
 }
 
 fmi2Status FMI2FreeFMUstate(FMIInstance *instance, fmi2FMUstate* FMUstate) {
-    CALL_ARGS(FreeFMUstate, "FMUstate=0x%p", FMUstate)
+    CALL_ARGS(FreeFMUstate, "FMUstate=0x%p", FMUstate);
 }
 
 fmi2Status FMI2SerializedFMUstateSize(FMIInstance *instance, fmi2FMUstate  FMUstate, size_t* size) {
@@ -342,7 +354,7 @@ fmi2Status FMI2GetDirectionalDerivative(FMIInstance *instance,
     const fmi2Real dvKnown[],
     fmi2Real dvUnknown[]) {
     CALL_ARGS(GetDirectionalDerivative, "vUnknown_ref=0x%p, nUnknown=%zu, vKnown_ref=0x%p, nKnown=%zu, dvKnown=0x%p, dvUnknown=0x%p",
-        vUnknown_ref, nUnknown, vKnown_ref, nKnown, dvKnown, dvUnknown)
+        vUnknown_ref, nUnknown, vKnown_ref, nKnown, dvKnown, dvUnknown);
 }
 
 /***************************************************
@@ -352,7 +364,7 @@ Model Exchange
 /* Enter and exit the different modes */
 fmi2Status FMI2EnterEventMode(FMIInstance *instance) {
     instance->state = FMI2EventModeState;
-    CALL(EnterEventMode)
+    CALL(EnterEventMode);
 }
 
 fmi2Status FMI2NewDiscreteStates(FMIInstance *instance, fmi2EventInfo *eventInfo) {
@@ -367,7 +379,7 @@ fmi2Status FMI2NewDiscreteStates(FMIInstance *instance, fmi2EventInfo *eventInfo
 
 fmi2Status FMI2EnterContinuousTimeMode(FMIInstance *instance) {
     instance->state = FMI2ContinuousTimeModeState;
-    CALL(EnterContinuousTimeMode)
+    CALL(EnterContinuousTimeMode);
 }
 
 fmi2Status FMI2CompletedIntegratorStep(FMIInstance *instance,
@@ -384,7 +396,7 @@ fmi2Status FMI2CompletedIntegratorStep(FMIInstance *instance,
 /* Providing independent variables and re-initialization of caching */
 fmi2Status FMI2SetTime(FMIInstance *instance, fmi2Real time) {
     instance->time = time;
-    CALL_ARGS(SetTime, "time=%.16g", time)
+    CALL_ARGS(SetTime, "time=%.16g", time);
 }
 
 fmi2Status FMI2SetContinuousStates(FMIInstance *instance, const fmi2Real x[], size_t nx) {
@@ -449,7 +461,7 @@ fmi2Status FMI2GetRealOutputDerivatives(FMIInstance *instance,
     const fmi2ValueReference vr[], size_t nvr,
     const fmi2Integer order[],
     fmi2Real value[]) {
-    CALL_ARGS(GetRealOutputDerivatives, "vr=0x%p, nvr=%zu, order=0x%p, value=0x%p", vr, nvr, order, value)
+    CALL_ARGS(GetRealOutputDerivatives, "vr=0x%p, nvr=%zu, order=0x%p, value=0x%p", vr, nvr, order, value);
 }
 
 fmi2Status FMI2DoStep(FMIInstance *instance,
@@ -460,7 +472,7 @@ fmi2Status FMI2DoStep(FMIInstance *instance,
     instance->time = currentCommunicationPoint + communicationStepSize;
 
     CALL_ARGS(DoStep, "currentCommunicationPoint=%.16g, communicationStepSize=%.16g, noSetFMUStatePriorToCurrentPoint=%d",
-        currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint)
+        currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint);
 }
 
 fmi2Status FMI2CancelStep(FMIInstance *instance) {

--- a/src/FMI3.c
+++ b/src/FMI3.c
@@ -38,40 +38,51 @@ static void cb_logMessage3(fmi3InstanceEnvironment instanceEnvironment,
 
 #if defined(FMI2_FUNCTION_PREFIX)
 #define LOAD_SYMBOL(f) \
-    instance->fmi3Functions->fmi3 ## f = fmi3 ## f;
+do { \
+    instance->fmi3Functions->fmi3 ## f = fmi3 ## f; \
+} while (0)
 #elif defined(_WIN32)
 #define LOAD_SYMBOL(f) \
+do { \
     instance->fmi3Functions->fmi3 ## f = (fmi3 ## f ## TYPE*)GetProcAddress(instance->libraryHandle, "fmi3" #f); \
     if (!instance->fmi3Functions->fmi3 ## f) { \
         instance->logMessage(instance, FMIFatal, "fatal", "Symbol fmi3" #f " is missing in shared library."); \
         return fmi3Fatal; \
-    }
+    } \
+} while (0)
 #else
 #define LOAD_SYMBOL(f) \
+do { \
     instance->fmi3Functions->fmi3 ## f = (fmi3 ## f ## TYPE*)dlsym(instance->libraryHandle, "fmi3" #f); \
     if (!instance->fmi3Functions->fmi3 ## f) { \
         instance->logMessage(instance, FMIFatal, "fatal", "Symbol fmi3" #f " is missing in shared library."); \
         return fmi3Fatal; \
-    }
+    } \
+} while (0)
 #endif
 
 #define CALL(f) \
+do { \
     fmi3Status status = instance->fmi3Functions->fmi3 ## f (instance->component); \
     if (instance->logFunctionCall) { \
         instance->logFunctionCall(instance, status, "fmi3" #f "()"); \
     } \
     instance->status = status > instance->status ? status : instance->status; \
-    return status;
+    return status; \
+} while (0)
 
 #define CALL_ARGS(f, m, ...) \
+do { \
     fmi3Status status = instance->fmi3Functions-> fmi3 ## f (instance->component, __VA_ARGS__); \
     if (instance->logFunctionCall) { \
         instance->logFunctionCall(instance, status, "fmi3" #f "(" m ")", __VA_ARGS__); \
     } \
     instance->status = status > instance->status ? status : instance->status; \
-    return status;
+    return status; \
+} while (0)
 
 #define CALL_ARRAY(s, t) \
+do { \
     fmi3Status status = instance->fmi3Functions->fmi3 ## s ## t(instance->component, valueReferences, nValueReferences, values, nValues); \
     if (instance->logFunctionCall) { \
         FMIValueReferencesToString(instance, valueReferences, nValueReferences); \
@@ -79,7 +90,8 @@ static void cb_logMessage3(fmi3InstanceEnvironment instanceEnvironment,
         instance->logFunctionCall(instance, status, "fmi3" #s #t "(valueReferences=%s, nValueReferences=%zu, values=%s, nValues=%zu)", instance->buf1, nValueReferences, instance->buf2, nValues); \
     } \
     instance->status = status > instance->status ? status : instance->status; \
-    return status;
+    return status; \
+} while (0)
 
 /***************************************************
 Types for Common Functions

--- a/src/cosimulation.c
+++ b/src/cosimulation.c
@@ -233,207 +233,207 @@ void logError(ModelInstance *comp, const char *message, ...) {
 // default implementations
 #if NZ < 1
 void getEventIndicators(ModelInstance *comp, double z[], size_t nz) {
-    UNUSED(comp)
-    UNUSED(z)
-    UNUSED(nz)
+    UNUSED(comp);
+    UNUSED(z);
+    UNUSED(nz);
     // do nothing
 }
 #endif
 
 #ifndef GET_UINT16
 Status getUInt16(ModelInstance* comp, ValueReference vr, uint16_t *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef GET_INT32
 Status getInt32(ModelInstance* comp, ValueReference vr, int *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef GET_UINT64
 Status getUInt64(ModelInstance* comp, ValueReference vr, uint64_t *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef GET_BOOLEAN
 Status getBoolean(ModelInstance* comp, ValueReference vr, bool *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef GET_STRING
 Status getString(ModelInstance* comp, ValueReference vr, const char **value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef GET_BINARY
 Status getBinary(ModelInstance* comp, ValueReference vr, size_t size[], const char *value[], size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(size)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(size);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef SET_FLOAT64
 Status setFloat64(ModelInstance* comp, ValueReference vr, const double *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef SET_UINT16
 Status setUInt16(ModelInstance* comp, ValueReference vr, const uint16_t *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef SET_INT32
 Status setInt32(ModelInstance* comp, ValueReference vr, const int *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef SET_UINT64
 Status setUInt64(ModelInstance* comp, ValueReference vr, const uint64_t *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef SET_BOOLEAN
 Status setBoolean(ModelInstance* comp, ValueReference vr, const bool *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef SET_STRING
 Status setString(ModelInstance* comp, ValueReference vr, const char *const *value, size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef SET_BINARY
 Status setBinary(ModelInstance* comp, ValueReference vr, const size_t size[], const char *const value[], size_t *index) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(size)
-    UNUSED(value)
-    UNUSED(index)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(size);
+    UNUSED(value);
+    UNUSED(index);
     return Error;
 }
 #endif
 
 #ifndef ACTIVATE_CLOCK
 Status activateClock(ModelInstance* comp, ValueReference vr) {
-    UNUSED(comp)
-    UNUSED(vr)
+    UNUSED(comp);
+    UNUSED(vr);
     return Error;
 }
 #endif
 
 #ifndef GET_CLOCK
 Status getClock(ModelInstance* comp, ValueReference vr, bool* value) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(value)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(value);
     return Error;
 }
 #endif
 
 #ifndef GET_INTERVAL
 Status getInterval(ModelInstance* comp, ValueReference vr, double* interval, int* qualifier) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(interval)
-    UNUSED(qualifier)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(interval);
+    UNUSED(qualifier);
     return Error;
 }
 #endif
 
 #ifndef ACTIVATE_MODEL_PARTITION
 Status activateModelPartition(ModelInstance* comp, ValueReference vr, double activationTime) {
-    UNUSED(comp)
-    UNUSED(vr)
-    UNUSED(activationTime)
+    UNUSED(comp);
+    UNUSED(vr);
+    UNUSED(activationTime);
     return Error;
 }
 #endif
 
 #if NX < 1
 void getContinuousStates(ModelInstance *comp, double x[], size_t nx) {
-    UNUSED(comp)
-    UNUSED(x)
-    UNUSED(nx)
+    UNUSED(comp);
+    UNUSED(x);
+    UNUSED(nx);
 }
 
 void setContinuousStates(ModelInstance *comp, const double x[], size_t nx) {
-    UNUSED(comp)
-    UNUSED(x)
-    UNUSED(nx)
+    UNUSED(comp);
+    UNUSED(x);
+    UNUSED(nx);
 }
 
 void getDerivatives(ModelInstance *comp, double dx[], size_t nx) {
-    UNUSED(comp)
-    UNUSED(dx)
-    UNUSED(nx)
+    UNUSED(comp);
+    UNUSED(dx);
+    UNUSED(nx);
 }
 #endif
 
 #ifndef GET_PARTIAL_DERIVATIVE
 Status getPartialDerivative(ModelInstance *comp, ValueReference unknown, ValueReference known, double *partialDerivative) {
-    UNUSED(comp)
-    UNUSED(unknown)
-    UNUSED(known)
-    UNUSED(partialDerivative)
+    UNUSED(comp);
+    UNUSED(unknown);
+    UNUSED(known);
+    UNUSED(partialDerivative);
     return Error;
 }
 #endif

--- a/src/fmi1Functions.c
+++ b/src/fmi1Functions.c
@@ -26,66 +26,76 @@
 #endif
 
 #define ASSERT_NOT_NULL(p) \
-if (!p) { \
-    logError(S, "Argument %s must not be NULL.", xstr(p)); \
-    S->state = modelError; \
-    return (fmiStatus)Error; \
-}
+do { \
+    if (!p) { \
+        logError(S, "Argument %s must not be NULL.", xstr(p)); \
+        S->state = modelError; \
+        return (fmiStatus)Error; \
+    } \
+} while (0)
 
 #define GET_VARIABLES(T) \
-ASSERT_NOT_NULL(vr); \
-ASSERT_NOT_NULL(value); \
-size_t index = 0; \
-Status status = OK; \
-if (nvr == 0) return (fmiStatus)status; \
-if (S->isDirtyValues) { \
-    Status s = calculateValues(S); \
-    status = max(status, s); \
-    if (status > Warning) return (fmiStatus)status; \
-    S->isDirtyValues = false; \
-} \
-for (size_t i = 0; i < nvr; i++) { \
-    Status s = get ## T(S, vr[i], value, &index); \
-    status = max(status, s); \
-    if (status > Warning) return (fmiStatus)status; \
-} \
-return (fmiStatus)status;
+do { \
+    ASSERT_NOT_NULL(vr); \
+    ASSERT_NOT_NULL(value); \
+    size_t index = 0; \
+    Status status = OK; \
+    if (nvr == 0) return (fmiStatus)status; \
+    if (S->isDirtyValues) { \
+        Status s = calculateValues(S); \
+        status = max(status, s); \
+        if (status > Warning) return (fmiStatus)status; \
+        S->isDirtyValues = false; \
+    } \
+    for (size_t i = 0; i < nvr; i++) { \
+        Status s = get ## T(S, vr[i], value, &index); \
+        status = max(status, s); \
+        if (status > Warning) return (fmiStatus)status; \
+    } \
+    return (fmiStatus)status; \
+} while (0)
 
 #define SET_VARIABLES(T) \
-ASSERT_NOT_NULL(vr); \
-ASSERT_NOT_NULL(value); \
-size_t index = 0; \
-Status status = OK; \
-for (size_t i = 0; i < nvr; i++) { \
-    Status s = set ## T(S, vr[i], value, &index); \
-    status = max(status, s); \
-    if (status > Warning) return (fmiStatus)status; \
-} \
-if (nvr > 0) S->isDirtyValues = true; \
-return (fmiStatus)status;
+do { \
+    ASSERT_NOT_NULL(vr); \
+    ASSERT_NOT_NULL(value); \
+    size_t index = 0; \
+    Status status = OK; \
+    for (size_t i = 0; i < nvr; i++) { \
+        Status s = set ## T(S, vr[i], value, &index); \
+        status = max(status, s); \
+        if (status > Warning) return (fmiStatus)status; \
+    } \
+    if (nvr > 0) S->isDirtyValues = true; \
+    return (fmiStatus)status; \
+} while (0)
 
 #define GET_BOOLEAN_VARIABLES \
-Status status = OK; \
-for (size_t i = 0; i < nvr; i++) { \
-    bool v = false; \
-    size_t index = 0; \
-    Status s = getBoolean(S, vr[i], &v, &index); \
-    value[i] = v; \
-    status = max(status, s); \
-    if (status > Warning) return (fmiStatus)status; \
-} \
-return (fmiStatus)status;
+do { \
+    Status status = OK; \
+    for (size_t i = 0; i < nvr; i++) { \
+        bool v = false; \
+        size_t index = 0; \
+        Status s = getBoolean(S, vr[i], &v, &index); \
+        value[i] = v; \
+        status = max(status, s); \
+        if (status > Warning) return (fmiStatus)status; \
+    } \
+    return (fmiStatus)status; \
+} while (0)
 
 #define SET_BOOLEAN_VARIABLES \
-Status status = OK; \
-for (size_t i = 0; i < nvr; i++) { \
-    bool v = value[i]; \
-    size_t index = 0; \
-    Status s = setBoolean(S, vr[i], &v, &index); \
-    status = max(status, s); \
-    if (status > Warning) return (fmiStatus)status; \
-} \
-return (fmiStatus)status;
+do { \
+    Status status = OK; \
+    for (size_t i = 0; i < nvr; i++) { \
+        bool v = value[i]; \
+        size_t index = 0; \
+        Status s = setBoolean(S, vr[i], &v, &index); \
+        status = max(status, s); \
+        if (status > Warning) return (fmiStatus)status; \
+    } \
+    return (fmiStatus)status; \
+} while (0)
 
 #ifndef max
 #define max(a,b) ((a)>(b) ? (a) : (b))
@@ -96,7 +106,8 @@ return (fmiStatus)status;
 #endif
 
 #define ASSERT_STATE(F, A) \
-    if (!c) return fmiError; \
+    if (!c) \
+        return fmiError; \
     ModelInstance* S = (ModelInstance *)c; \
     if (invalidState(S, F, not_modelError)) \
         return fmiError;


### PR DESCRIPTION
This is the preferred style for larger macro declarations and has two advantages

* Declared local variables will be properly scoped variables then
* It is always safe to use a trailing semicolon when macro will be called. Currently it is inconsistent for the `UNUSED` and `CALL...` macros.