### PR TITLE
Use x86 prefix for 32 bit platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if (${FMI_VERSION} GREATER 2)
   if ("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
     set (FMI_PLATFORM x86_64-${FMI_PLATFORM})
   else ()
-    set (FMI_PLATFORM i686-${FMI_PLATFORM})
+    set (FMI_PLATFORM x86-${FMI_PLATFORM})
   endif ()
 
 else ()


### PR DESCRIPTION
"2.5.1.4.1. Platform Tuple Definition" of the current 3.0-beta4 standard defines that "x86" has to be used for 32bit platforms