### PR TITLE
Allow early return

### DIFF
--- a/examples/cs_event_mode.c
+++ b/examples/cs_event_mode.c
@@ -21,7 +21,7 @@ int main(int argc, char* argv[]) {
         fmi3False,           // visible
         fmi3False,           // loggingOn
         fmi3True,            // eventModeUsed
-        fmi3False,           // earlyReturnAllowed
+        fmi3True,            // earlyReturnAllowed
         NULL,                // requiredIntermediateVariables
         0,                   // nRequiredIntermediateVariables
         NULL                 // intermediateUpdate


### PR DESCRIPTION
This code is used in the specification and the FMU in the example returns early, so this must be allowed by the simulation algorithm.