### PR TITLE
Be more verbose on building/running/testing FMUs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest --junitxml=junit/test-results.xml
+        pytest -s -v --junitxml=junit/test-results.xml
 
     - name: Upload FMUs
       uses: actions/upload-artifact@v3
@@ -78,7 +78,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest --junitxml=junit/test-results.xml
+        pytest -s -v --junitxml=junit/test-results.xml
 
     - name: Upload FMUs
       uses: actions/upload-artifact@v3
@@ -115,7 +115,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest --junitxml=junit/test-results.xml
+        pytest -s -v --junitxml=junit/test-results.xml
 
     - name: Upload FMUs
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
It is rather hidden that FMUs are built via pytest as nothing is dumped to output. This PR increases their verbosity.