### PR TITLE
Add Clang format (check) to GitHub Actions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,27 @@
+---
+BasedOnStyle: Google
+Language: Cpp
+Standard: Cpp03
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 120
+NamespaceIndentation: All
+
+AccessModifierOffset: -4
+ContinuationIndentWidth: 4
+IndentWidth: 4
+
+BreakBeforeBraces: Attach
+
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: None
+AllowShortBlocksOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+AlignConsecutiveAssignments: true
+AlignTrailingComments: true
+ReflowComments: false
+SortIncludes: false
+
+...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,60 @@ jobs:
     - name: Lint files
       run: python3 lint_files.py
 
+  clang-format-check-files:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Clang format check files
+      uses: DoozyX/clang-format-lint-action@v0.14
+      with:
+        source: 'examples BouncingBall Clocks Dahlquist Feedthrough LinearTransform Resource Stair VanDerPol'
+        extensions: 'c,h'
+        clangFormatVersion: 14
+        inplace: False
+
+  clang-format-files:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Clang format files
+      uses: DoozyX/clang-format-lint-action@v0.14
+      with:
+        source: 'examples BouncingBall Clocks Dahlquist Feedthrough LinearTransform Resource Stair VanDerPol'
+        extensions: 'c,h'
+        clangFormatVersion: 14
+        inplace: True
+
+    - name: Upload Clang formatted files
+      uses: actions/upload-artifact@v3
+      with:
+        name: clang-formatted-files
+        path: |
+          examples/*.c
+          BouncingBall/*.c
+          Clocks/*.c
+          Dahlquist/*.c
+          Feedthrough/*.c
+          LinearTransform/*.c
+          Resource/*.c
+          Stair/*.c
+          VanDerPol/*.c
+          examples/*.h
+          BouncingBall/*.h
+          Clocks/*.h
+          Dahlquist/*.h
+          Feedthrough/*.h
+          LinearTransform/*.h
+          Resource/*.h
+          Stair/*.h
+          VanDerPol/*.h
+
   build-linux:
 
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Resolves #116

Remaining tasks are to:

- [ ] define desired Clang format settings (there are hundreds of options)
- [ ] decide if Clang format is only checked in CI or even formatted inplace and pushed