### PR TITLE
Escape underscores in readme

### DIFF
--- a/Feedthrough/readme.md
+++ b/Feedthrough/readme.md
@@ -1,15 +1,15 @@
 # Feedthrough
 
-| Variable         | Start     | Causality | Variability | Description
-|:-----------------| ----------|-----------|-------------|:---------------
-| real_fixed_param | 0         | parameter | fixed       | Fixed parameter
-| string_param     | "Set me!" | parameter | fixed       | String parameter
+| Variable                  | Start     | Causality | Variability | Description
+|:--------------------------| ----------|-----------|-------------|:---------------
+| Float64\_fixed\_parameter | 0         | parameter | fixed       | Fixed parameter
+| String\_parameter         | "Set me!" | parameter | fixed       | String parameter
 
 In order to reproduce the reference results the following parameters need to be set
 
 ```
-real_fixed_param: 1
-string_param:     "FMI is awesome!"
+Float64_fixed_parameter: 1
+String_parameter:        "FMI is awesome!"
 ```
 
 and the [input signals](Feedthrough_in.csv) must be applied.


### PR DESCRIPTION
Shouldn't all variables be listed in the Readme file?