### PR TITLE
Define WIN32_LEAN_AND_MEAN

### DIFF
--- a/examples/import_shared_library.c
+++ b/examples/import_shared_library.c
@@ -1,6 +1,9 @@
 /* This example demonstrates how to import an FMU implemented as a shared library */
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
 #else
 #include <dlfcn.h>

--- a/examples/scs_threaded.c
+++ b/examples/scs_threaded.c
@@ -5,6 +5,9 @@
 #include <stdarg.h>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <strsafe.h>
 #include <process.h>

--- a/include/FMI.h
+++ b/include/FMI.h
@@ -13,6 +13,9 @@ extern "C" {
 #endif
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
 #endif
 


### PR DESCRIPTION
This excludes Win APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets and thus speeds up compilation.