### PR TITLE
Fix compiler warning C4090: 'function': different 'const' qualifiers

### DIFF
--- a/src/FMI.c
+++ b/src/FMI.c
@@ -101,7 +101,7 @@ void FMIFreeInstance(FMIInstance *instance) {
 
     free(instance->buf1);
     free(instance->buf2);
-    free(instance->name);
+    free((void*)instance->name);
 
     free(instance->fmi1Functions);
     free(instance->fmi2Functions);


### PR DESCRIPTION
Regression of #292.