### PR TITLE
Add discrete variability in FMI 3 Feedthrough FMU

### DIFF
--- a/Feedthrough/FMI3.xml
+++ b/Feedthrough/FMI3.xml
@@ -29,8 +29,8 @@
 
     <Float32 name="Float32_continuous_input"  valueReference="1" causality="input" start="0"/>
     <Float32 name="Float32_continuous_output" valueReference="2" causality="output"/>
-    <Float32 name="Float32_discrete_input"    valueReference="3" causality="input" start="0"/>
-    <Float32 name="Float32_discrete_output"   valueReference="4" causality="output"/>
+    <Float32 name="Float32_discrete_input"    valueReference="3" causality="input" variability="discrete" start="0"/>
+    <Float32 name="Float32_discrete_output"   valueReference="4" causality="output" variability="discrete"/>
 
     <Float64 name="Float64_fixed_parameter" valueReference="5" causality="parameter" variability="fixed" start="0"/>
     <Float64 name="Float64_tunable_parameter" valueReference="6" causality="parameter" variability="tunable" start="0"/>


### PR DESCRIPTION
The model variables "Float32_discrete_input" and "Float32_discrete_output" of the FMI 3 Feedthrough FMU are missing the discrete variability attribute. This may cause issues in a standard conforming importer because it may try to set the variable during an illegal mode, e.g., during the Continuous Time mode.

This adds the discrete attribute to both variables which is in line with the "Float64_discrete_input" and "Float64_discrete_output" variables which already have the discrete variability attribute.