### PR TITLE
Set instance->time to startTime in FMI3EnterInitializationMode()

### DIFF
--- a/src/FMI3.c
+++ b/src/FMI3.c
@@ -468,6 +468,8 @@ FMIStatus FMI3EnterInitializationMode(FMIInstance *instance,
 
     instance->state = FMI2InitializationModeState;
 
+    instance->time = startTime;
+
     CALL_ARGS(EnterInitializationMode,
         "fmi3EnterInitializationMode(toleranceDefined=%d, tolerance=%.16g, startTime=%.16g, stopTimeDefined=%d, stopTime=%.16g)",
         toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);


### PR DESCRIPTION
fixes #371