### PR TITLE
Make void argument explicit in function typedefs

### DIFF
--- a/include/fmi3FunctionTypes.h
+++ b/include/fmi3FunctionTypes.h
@@ -103,8 +103,8 @@ typedef void (*fmi3IntermediateUpdateCallback) (
 /* end::CallbackIntermediateUpdate[] */
 
 /* tag::CallbackPreemptionLock[] */
-typedef void (*fmi3LockPreemptionCallback)   ();
-typedef void (*fmi3UnlockPreemptionCallback) ();
+typedef void (*fmi3LockPreemptionCallback)   (void);
+typedef void (*fmi3UnlockPreemptionCallback) (void);
 /* end::CallbackPreemptionLock[] */
 
 /* Define fmi3 function pointer types to simplify dynamic loading */

--- a/include/model.h
+++ b/include/model.h
@@ -87,8 +87,9 @@ typedef void (*loggerType) (void *componentEnvironment, const char *instanceName
 typedef void (*loggerType) (void *componentEnvironment, int status, const char *category, const char *message);
 #endif
 
-typedef void (*lockPreemptionType)   ();
-typedef void (*unlockPreemptionType) ();
+typedef void (*lockPreemptionType)   (void);
+typedef void (*unlockPreemptionType) (void);
+
 
 typedef void (*intermediateUpdateType) (void *instanceEnvironment,
                                         double intermediateUpdateTime,

--- a/src/fmi2Functions.c
+++ b/src/fmi2Functions.c
@@ -309,11 +309,11 @@ void fmi2FreeInstance(fmi2Component c) {
 // FMI functions: class methods not depending of a specific model instance
 // ---------------------------------------------------------------------------
 
-const char* fmi2GetVersion() {
+const char* fmi2GetVersion(void) {
     return fmi2Version;
 }
 
-const char* fmi2GetTypesPlatform() {
+const char* fmi2GetTypesPlatform(void) {
     return fmi2TypesPlatform;
 }
 


### PR DESCRIPTION
CMake build could fail when building with -Werror and -Wstrict-prototypes due to implicit void argument in function typedefs.

This pull request adds explicit void arguments to the following:

* `typedef void (*lockPreemptionType)   (void)`
* `typedef void (*unlockPreemptionType) (void)`
* `const char* fmi2GetVersion(void)`
* `const char* fmi2GetTypesPlatform(void)`