### PR TITLE
Remove unused eventInfo from FMI{1|2}Functions structs

### DIFF
--- a/include/FMI1.h
+++ b/include/FMI1.h
@@ -14,7 +14,6 @@ struct FMI1Functions_ {
     ****************************************************/
 
     fmi1CallbackFunctions   callbacks;
-    fmi1EventInfo           eventInfo;
 
     fmi1SetRealTYPE         *fmi1SetReal;
     fmi1SetIntegerTYPE      *fmi1SetInteger;

--- a/include/FMI2.h
+++ b/include/FMI2.h
@@ -10,7 +10,6 @@ extern "C" {
 struct FMI2Functions_ {
 
     fmi2CallbackFunctions            callbacks;
-    fmi2EventInfo                    eventInfo;
 
     /***************************************************
     Common Functions for FMI 2.0

--- a/src/FMI2.c
+++ b/src/FMI2.c
@@ -146,13 +146,6 @@ FMIStatus FMI2Instantiate(FMIInstance *instance, const char *fmuResourceLocation
         return FMIError;
     }
 
-    instance->fmi2Functions->eventInfo.newDiscreteStatesNeeded           = fmi2False;
-    instance->fmi2Functions->eventInfo.terminateSimulation               = fmi2False;
-    instance->fmi2Functions->eventInfo.nominalsOfContinuousStatesChanged = fmi2False;
-    instance->fmi2Functions->eventInfo.valuesOfContinuousStatesChanged   = fmi2False;
-    instance->fmi2Functions->eventInfo.nextEventTimeDefined              = fmi2False;
-    instance->fmi2Functions->eventInfo.nextEventTime                     = 0.0;
-
     instance->state = FMIStartAndEndState;
 
 #if !defined(FMI_VERSION) || FMI_VERSION == 2


### PR DESCRIPTION
fixes #364