### PR TITLE
Fix event handling w/o early return

### DIFF
--- a/src/fmi3Functions.c
+++ b/src/fmi3Functions.c
@@ -1341,11 +1341,19 @@ fmi3Status fmi3DoStep(fmi3Instance instance,
 
     while (true) {
 
-        nextCommunicationPointReached = S->time + FIXED_SOLVER_STEP > nextCommunicationPoint;
+        const fmi3Float64 nextSolverStepTime = S->time + FIXED_SOLVER_STEP;
+        nextCommunicationPointReached = nextSolverStepTime > nextCommunicationPoint;
 
-        if (nextCommunicationPointReached) {
+        if (nextCommunicationPointReached || *eventHandlingNeeded && S->earlyReturnAllowed) {
             break;
         }
+
+#ifdef EVENT_UPDATE
+        if (*eventHandlingNeeded) {
+            eventUpdate(S);
+            *eventHandlingNeeded = fmi3False;
+        }
+#endif
 
         bool stateEvent, timeEvent;
 

--- a/src/fmi3Functions.c
+++ b/src/fmi3Functions.c
@@ -1344,7 +1344,7 @@ fmi3Status fmi3DoStep(fmi3Instance instance,
         const fmi3Float64 nextSolverStepTime = S->time + FIXED_SOLVER_STEP;
         nextCommunicationPointReached = nextSolverStepTime > nextCommunicationPoint;
 
-        if (nextCommunicationPointReached || *eventHandlingNeeded && S->earlyReturnAllowed) {
+        if (nextCommunicationPointReached || (*eventHandlingNeeded && S->earlyReturnAllowed)) {
             break;
         }
 


### PR DESCRIPTION
Fixes #421, #420, #236

- The FMU does not return early if early return is not allowed
- The FMU does not return earlyReturn = true, if it does not return early
- The FMU does not return eventHandlingNeeded = true, if the event has already been handled by the FMU