### PR TITLE
Fix memory leak in example FMUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ endif ()
 # hide internal functions
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+  if (WITH_MEMORY_SANITIZER)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+  endif()
 endif()
 
 if (${FMI_VERSION} GREATER 2)

--- a/src/cosimulation.c
+++ b/src/cosimulation.c
@@ -104,6 +104,9 @@ ModelInstance *createModelInstance(
 }
 
 void freeModelInstance(ModelInstance *comp) {
+    if (comp->resourceLocation) {
+        free((void *)comp->resourceLocation);
+    }
     free((void *)comp->instanceName);
     free(comp);
 }


### PR DESCRIPTION
Fix: #427 

## Why?

When using example FMUs dynamic libraries, we realize in our sanity checks that there are memory leaks.
By further analysis, we reach the conclusion that these leaks come from FMUs' ModelInstance resource location string that is owned by an FMU component but never properly deallocated.

The following images show the output of gcc address sanitizer when running examples `BouncingBall_cs` and `Feedthrough_me`. It demonstrate that this behaviour happens in different FMUs.

![pathless_modelica_leak_bouncingball](https://github.com/modelica/Reference-FMUs/assets/149105301/f0e01df0-6325-467a-a4fb-0866470e7d4e)

![pathless_modelica_leak_feedthrough](https://github.com/modelica/Reference-FMUs/assets/149105301/d3e63e7f-df97-4600-b7f6-7af336d2ee1e)

This PR fixes this problem by deallocating the ModelInstance's resource location when freeModelInstance is called.

## What?

* Add an option in CMake to enable address sanitize compilation to check this behavior by using `-DWITH_MEMORY_SANITIZER=ON`
* Change `freeModelInstance` in cosimulation to deallocate `ModelInstance *comp`,  `comp->resourceLocation` when `resourceLocation` is allocatted.