### PR TITLE
Call configurate() for FMI 1.0 & 2.0 in Co-Simulation

### DIFF
--- a/src/cosimulation.c
+++ b/src/cosimulation.c
@@ -154,7 +154,7 @@ Status configurate(ModelInstance* comp) {
     comp->nz = getNumberOfEventIndicators(comp);
 
     if (comp->nz > 0) {
-        CALL(s_reallocate(comp, (void**)& comp->prez, comp->nz * sizeof(double)));
+        CALL(s_reallocate(comp, (void**)&comp->prez, comp->nz * sizeof(double)));
         CALL(s_reallocate(comp, (void**)&comp->z, comp->nz * sizeof(double)));
     }
 

--- a/src/fmi1Functions.c
+++ b/src/fmi1Functions.c
@@ -227,6 +227,8 @@ fmiStatus fmiInitializeSlave(fmiComponent c, fmiReal tStart, fmiBoolean StopTime
     instance->stopTime = StopTimeDefined ? tStop : INFINITY;
     instance->time = tStart;
 
+    configurate(instance);
+
     return init(c);
 }
 

--- a/src/fmi2Functions.c
+++ b/src/fmi2Functions.c
@@ -268,6 +268,8 @@ fmi2Status fmi2ExitInitializationMode(fmi2Component c) {
 
     S->state = S->type == ModelExchange ? EventMode : StepComplete;
 
+    CALL(configurate(S));
+
     END_FUNCTION();
 }
 


### PR DESCRIPTION
fixes #457