### PR TITLE
Add process ID to temp folder name on Windows

### DIFF
--- a/fmusim/FMIZip.c
+++ b/fmusim/FMIZip.c
@@ -22,7 +22,13 @@
 const char* FMICreateTemporaryDirectory() {
     
 #ifdef _WIN32
-    const char* tempfile = _tempnam(NULL, NULL);
+    DWORD processId = GetCurrentProcessId();
+
+    char prefix[256] = "fmusim.";
+    
+    sprintf(&prefix[7], "%lu", processId);
+
+    const char* tempfile = _tempnam(NULL, prefix);
     
     if (!tempfile) {
         return NULL;


### PR DESCRIPTION
to avoid clashes during parallel execution

fixes #633