### PR TITLE
Fixing FMI2 Feedthrough dependencies

### DIFF
--- a/Feedthrough/FMI2.xml
+++ b/Feedthrough/FMI2.xml
@@ -94,18 +94,18 @@
 
   <ModelStructure>
     <Outputs>
-      <Unknown index="5" dependencies="2 3 4" dependenciesKind="constant constant constant"/>
+      <Unknown index="5" dependencies="4" dependenciesKind="constant"/>
       <Unknown index="7" dependencies="6" dependenciesKind="constant"/>
       <Unknown index="9" dependencies="8" dependenciesKind="constant"/>
-      <Unknown index="11" dependencies="10 12" dependenciesKind="constant"/>
+      <Unknown index="11" dependencies="10" dependenciesKind="constant"/>
       <Unknown index="13" dependencies="12" dependenciesKind="constant"/>
       <Unknown index="15" dependencies="14" dependenciesKind="constant"/>
     </Outputs>
     <InitialUnknowns>
-      <Unknown index="5" dependencies="2 3 4" dependenciesKind="constant constant constant"/>
+      <Unknown index="5" dependencies="4" dependenciesKind="constant"/>
       <Unknown index="7" dependencies="6" dependenciesKind="constant"/>
       <Unknown index="9" dependencies="8" dependenciesKind="constant"/>
-      <Unknown index="11" dependencies="10 12" dependenciesKind="constant"/>
+      <Unknown index="11" dependencies="10" dependenciesKind="constant"/>
       <Unknown index="13" dependencies="12" dependenciesKind="constant"/>
       <Unknown index="15" dependencies="14" dependenciesKind="constant"/>
     </InitialUnknowns>


### PR DESCRIPTION
The ones for `Float64_continuous_output` seem unnecessary, unless I am missing something.

The ones for `Boolean_output` were actually invalid XML due to the length mismatch of `dependencies` and `dependenciesKind`.