### PR TITLE
CI: Bump Windows Server

### DIFF
--- a/.github/workflows/build-fmusim-gui.yml
+++ b/.github/workflows/build-fmusim-gui.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-fmusim-gui:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -18,10 +18,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.7.1'
+        version: '6.8.3'
         host: 'windows'
         target: 'desktop'
-        arch: 'win64_msvc2019_64'
+        arch: 'win64_msvc2022_64'
         modules: 'qtpositioning qtwebchannel qtwebengine'
     - run: python -m pip install fmpy requests
     - run: python fmusim-gui/build/build_cvode.py


### PR DESCRIPTION
> Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045