### PR TITLE
Add dependencies for state space model

### DIFF
--- a/StateSpace/FMI3.xml
+++ b/StateSpace/FMI3.xml
@@ -67,11 +67,11 @@
     </ModelVariables>
 
     <ModelStructure>
-        <Output valueReference="10"/>
-        <ContinuousStateDerivative valueReference="12"/>
-        <InitialUnknown valueReference="10"/>
-        <InitialUnknown valueReference="11"/>
-        <InitialUnknown valueReference="12"/>
+        <Output valueReference="10" dependencies="6 7 9 11"/>
+        <ContinuousStateDerivative valueReference="12" dependencies="4 5 9 11"/>
+        <InitialUnknown valueReference="10" dependencies="6 7 9 11"/>
+        <InitialUnknown valueReference="11" dependencies="8"/>
+        <InitialUnknown valueReference="12" dependencies="4 5 9 11"/>
     </ModelStructure>
 
 </fmiModelDescription>


### PR DESCRIPTION
Currently, all variables depend on all other variables. E.g.
y depends on der(x)
der(x) depends on y.
That's essentially an "algebraic" loop. I guess this is not intended.
Therefor I added explicit dependencies for all variables.